### PR TITLE
Full support for Monitored Entities

### DIFF
--- a/dynatrace/environment_v2/monitored_entities.py
+++ b/dynatrace/environment_v2/monitored_entities.py
@@ -15,9 +15,11 @@ limitations under the License.
 """
 
 from datetime import datetime
+from enum import Enum
+from requests import Response
 from typing import List, Optional, Union, Dict, Any
 
-from dynatrace.environment_v2.schemas import EntityType, ManagementZone
+from dynatrace.environment_v2.schemas import ManagementZone
 from dynatrace.http_client import HttpClient
 from dynatrace.configuration_v1.metag import METag
 from dynatrace.dynatrace_object import DynatraceObject
@@ -26,6 +28,9 @@ from dynatrace.utils import int64_to_datetime, timestamp_to_string
 
 
 class EntityService:
+    ENDPOINT_ENTITIES = "/api/v2/entities"
+    ENDPOINT_TYPES = "/api/v2/entityTypes"
+
     def __init__(self, http_client: HttpClient):
         self.__http_client = http_client
 
@@ -38,7 +43,25 @@ class EntityService:
         sort: Optional[str] = None,
         page_size: Optional[int] = None,
     ) -> PaginatedList["Entity"]:
-        """
+        """Gets the information about monitored entities.
+
+        Lists entities observed within the specified timeframe along with their properties.
+        When you query entities of the SERVICE_METHOD type, only the following requests are returned:
+            - Key requests
+            - Top X requests that are used for baselining
+            - Requests that have caused a problem
+
+        :param page_size: The amount of entities per page. If not set, 50 is used.
+        :param entity_selector: Defines the scope of the query. Only entities matching the specified criteria are included into response.
+                                You must set one of these criteria:
+                                    - Entity type: type("TYPE")
+                                    - Dynatrace entity ID: entityId("id"). Several IDs can be separated by a comma (entityId("id-1","id-2")).
+                                The length of the string is limited to 10,000 characters.
+        :param time_from: The start of the requested timeframe. If not set, the relative timeframe of three days is used (now-3d).
+        :param time_to: The end of the requested timeframe. If not set, the current timestamp is used.
+        :param fields: Defines the list of entity properties included in the response. The ID and the name of an entity are always included to the response.
+        :param sort: Defines the ordering of the entities returned. Currently ordering is only available for the display name (for example sort=name or sort =+name for ascending, sort=-name for descending)
+
         :return: A list of monitored entities along with their properties.
         """
         params = {
@@ -49,30 +72,99 @@ class EntityService:
             "fields": fields,
             "sort": sort,
         }
-        return PaginatedList(Entity, self.__http_client, "/api/v2/entities", target_params=params, list_item="entities")
+        return PaginatedList(Entity, self.__http_client, self.ENDPOINT_ENTITIES, target_params=params, list_item="entities")
 
     def get(
         self, entity_id: str, time_from: Optional[Union[datetime, str]] = None, time_to: Optional[Union[datetime, str]] = None, fields: Optional[str] = None
     ) -> "Entity":
+        """Gets the properties of the specified monitored entity.
+
+        :param entity_id: The ID of the required entity.
+        :param time_from: The start of the requested timeframe. If not set, the relative timeframe of three days is used (now-3d).
+        :param time_to: The end of the requested timeframe. If not set, the current timestamp is used.
+        :param fields: Defines the list of entity properties included in the response. The ID and the name of an entity are always included to the response.
+
+        :returns Entity: the monitored entity requested
+        """
         params = {"from": timestamp_to_string(time_from), "to": timestamp_to_string(time_to), "fields": fields}
-        response = self.__http_client.make_request(f"/api/v2/entities/{entity_id}", params=params).json()
+        response = self.__http_client.make_request(f"{self.ENDPOINT_ENTITIES}/{entity_id}", params=params).json()
         return Entity(raw_element=response)
 
-    def post_custom_device(self, device: "CustomDeviceCreation"):
-        # TODO - Implement
-        pass
+    def post_custom_device(self, device: "CustomDeviceCreation") -> "Response":
+        """Creates or updates a custom device.
 
-    def list_types(self, page_size=50) -> PaginatedList[EntityType]:
+        If the Custom Device ID matches an existing device, the respective parameters will be updated.
+
+        :returns Response: HTTP Response for the request
+        """
+        return device.post()
+
+    def create_custom_device(
+        self,
+        custom_device_id: str,
+        display_name: str,
+        group: Optional[str] = None,
+        ip_addresses: Optional[List[str]] = None,
+        listen_ports: Optional[List[int]] = None,
+        device_type: Optional[str] = None,
+        favicon_url: Optional[str] = None,
+        config_url: Optional[str] = None,
+        properties: Optional[Dict[str, str]] = None,
+        dns_names: Optional[List[str]] = None,
+        message_type: Optional["MessageType"] = None,
+    ) -> "CustomDeviceCreation":
+        """Creates a Custom Device object from scratch.
+
+        :param custom_device_id: The internal ID of the custom device. Max. length 512.
+        :param display_name: The name of the custom device to be displayed in the user interface.
+        :param group: User defined group ID of entity.
+        :param ip_addresses: The list of IP addresses that belong to the custom device.
+        :param listen_ports: The list of ports the custom devices listens to.
+        :param device_type: The technology type definition of the custom device.
+        :param favicon_url: The icon to be displayed for your custom component within Smartscape. Provide the full URL of the icon file.
+        :param config_url: The URL of a configuration web page for the custom device, such as a login page for a firewall or router.
+        :param properties: Key-value pair properties that will be shown beneath the infographics of your custom device.
+        :param dns_names: The list of DNS names related to the custom device.
+        :param message_type: Use the Enum for possible values
+
+        :returns CustomDeviceCreation: The resulting Custom Device. This can now be used in POST calls.
+        """
+        raw_device = {
+            "customDeviceId": custom_device_id,
+            "displayName": display_name,
+            "group": group,
+            "ipAddresses": ip_addresses,
+            "listenPorts": listen_ports,
+            "type": device_type,
+            "faviconUrl": favicon_url,
+            "configUrl": config_url,
+            "properties": properties,
+            "dnsNames": dns_names,
+            "messageType": message_type,
+        }
+        return CustomDeviceCreation(raw_element=raw_device, http_client=self.__http_client)
+
+    def list_types(self, page_size: Optional[int] = 50) -> PaginatedList["EntityType"]:
         """
         Gets a list of properties for all entity types
 
-        :param page_size: The desired amount of entities in a single response payload.
+        :param page_size: The amount of entity types in a single response payload.
             The maximal allowed page size is 500.
             If not set, 50 is used.
         :return: A list of properties of all available entity types.
         """
         params = {"pageSize": page_size}
-        return PaginatedList(EntityType, self.__http_client, "/api/v2/entityTypes", params, list_item="types")
+        return PaginatedList(EntityType, self.__http_client, self.ENDPOINT_TYPES, params, list_item="types")
+
+    def get_types(self, entity_type: str) -> "EntityType":
+        """Gets the properties of a specified entity type.
+
+        :param entity_type: The entity type required
+
+        :returns EntityType: The properties of the specified entity type.
+        """
+        response = self.__http_client.make_request(path=f"{self.ENDPOINT_TYPES}/{entity_type}")
+        return EntityType(raw_element=response.json())
 
 
 class Entity(DynatraceObject):
@@ -88,8 +180,8 @@ class Entity(DynatraceObject):
         }
         self.management_zones: List[ManagementZone] = [ManagementZone(m) for m in raw_element.get("managementZones", [])]
         self.icon: Optional[EntityIcon] = EntityIcon(raw_element=raw_element.get("icon")) if raw_element.get("icon") else None
-        self.display_name: str = raw_element.get("displayName")
-        self.entity_id: str = raw_element.get("entityId")
+        self.display_name: str = raw_element["displayName"]
+        self.entity_id: str = raw_element["entityId"]
         self.properties: Optional[Dict[str, Any]] = raw_element.get("properties", {})
         self.tags: List[METag] = [METag(raw_element=tag) for tag in raw_element.get("tags", [])]
 
@@ -106,14 +198,14 @@ class EntityShortRepresentation(DynatraceObject):
 
 class EntityStub(DynatraceObject):
     def _create_from_raw_data(self, raw_element: Dict[str, Any]):
-        self.entity_id: EntityId = EntityId(raw_element=raw_element.get("entityId"))
-        self.name: str = raw_element.get("name")
+        self.entity_id: EntityId = EntityId(raw_element=raw_element["entityId"])
+        self.name: str = raw_element["name"]
 
 
 class EntityId(DynatraceObject):
     def _create_from_raw_data(self, raw_element: Dict[str, Any]):
-        self.id: str = raw_element.get("id")
-        self.type: str = raw_element.get("type")
+        self.id: str = raw_element["id"]
+        self.type: str = raw_element["type"]
 
 
 class EntityIcon(DynatraceObject):
@@ -123,5 +215,82 @@ class EntityIcon(DynatraceObject):
         self.custom_icon_path = raw_element.get("customIconPath")
 
 
-class CustomDeviceCreation:
-    pass
+class CustomDeviceCreation(DynatraceObject):
+    def _create_from_raw_data(self, raw_element: Dict[str, Any]):
+        self.custom_device_id: str = raw_element["customDeviceId"]
+        self.display_name: str = raw_element["displayName"]
+        self.group: Optional[str] = raw_element.get("group")
+        self.ip_addresses: Optional[List[str]] = raw_element.get("ipAddresses")
+        self.listen_ports: Optional[List[int]] = raw_element.get("listenPorts")
+        self.type: Optional[str] = raw_element.get("type")
+        self.favicon_url: Optional[str] = raw_element.get("faviconUrl")
+        self.config_url: Optional[str] = raw_element.get("configUrl")
+        self.properties: Optional[Dict[str, str]] = raw_element.get("properties")
+        self.dns_names: Optional[List[str]] = raw_element.get("dnsNames")
+        self.message_type: Optional[MessageType] = MessageType(raw_element.get("messageType"))
+
+    def to_json(self):
+        return {
+            "customDeviceId": self.custom_device_id,
+            "displayName": self.display_name,
+            "group": self.group,
+            "ipAddresses": self.ip_addresses,
+            "listenPorts": self.listen_ports,
+            "type": self.type,
+            "faviconUrl": self.favicon_url,
+            "configUrl": self.config_url,
+            "properties": self.properties,
+            "dnsNames": self.dns_names,
+            "messageType": self.message_type,
+        }
+
+    def post(self) -> "Response":
+        return self._http_client.make_request(path=f"{EntityService.ENDPOINT_ENTITIES}/custom", method="POST", data=self.to_json())
+
+
+class EntityType(DynatraceObject):
+    def _create_from_raw_data(self, raw_element: dict):
+        self.type: str = raw_element["type"]
+        self.display_name: str = raw_element["displayName"]
+        self.entity_limit_exceeded: bool = raw_element.get("entityLimitExceeded", False)
+        self.properties: Optional[List[EntityTypePropertyDto]] = [EntityTypePropertyDto(raw_element=p) for p in raw_element.get("properties", [])]
+        self.from_relationships: Optional[List[FromPosition]] = [FromPosition(raw_element=fr) for fr in raw_element.get("fromRelationships", [])]
+        self.to_relationships: Optional[List[ToPosition]] = [ToPosition(raw_element=tr) for tr in raw_element.get("toRelationships", [])]
+        self.dimension_key: Optional[str] = raw_element.get("dimensionKey")
+        self.management_zones: Optional[str] = raw_element.get("managementZones")
+        self.tags: Optional[str] = raw_element.get("tags")
+
+
+class EntityTypePropertyDto(DynatraceObject):
+    def _create_from_raw_data(self, raw_element: Dict[str, Any]):
+        self.id: str = raw_element["id"]
+        self.type: str = raw_element["type"]
+        self.display_name: Optional[str] = raw_element.get("displayName")
+
+
+class ToPosition(DynatraceObject):
+    def _create_from_raw_data(self, raw_element: Dict[str, Any]):
+        self.from_types: List[str] = raw_element["fromTypes"]
+        self.id: str = raw_element["id"]
+
+
+class FromPosition(DynatraceObject):
+    def _create_from_raw_data(self, raw_element: Dict[str, Any]):
+        self.to_types: List[str] = raw_element["toTypes"]
+        self.id: str = raw_element["id"]
+
+
+class MessageType(Enum):
+    CUSTOM_DEVICE = "CUSTOM_DEVICE"
+    DELETE_ENTITY_PER_TYPE = "DELETE_ENTITY_PER_TYPE"
+    FILTER_VALUE_SUGGESTIONS = "FILTER_VALUE_SUGGESTIONS"
+    MULTI = "MULTI"
+    MULTI_TYPE = "MULTI_TYPE"
+    SINGLE = "SINGLE"
+    SINGLE_TYPE = "SINGLE_TYPE"
+
+    def __repr__(self):
+        return self.value
+
+    def __str__(self):
+        return self.value

--- a/dynatrace/environment_v2/monitored_entities.py
+++ b/dynatrace/environment_v2/monitored_entities.py
@@ -241,11 +241,11 @@ class CustomDeviceCreation(DynatraceObject):
             "configUrl": self.config_url,
             "properties": self.properties,
             "dnsNames": self.dns_names,
-            "messageType": self.message_type,
+            "messageType": str(self.message_type),
         }
 
     def post(self) -> "Response":
-        return self._http_client.make_request(path=f"{EntityService.ENDPOINT_ENTITIES}/custom", method="POST", data=self.to_json())
+        return self._http_client.make_request(path=f"{EntityService.ENDPOINT_ENTITIES}/custom", method="POST", params=self.to_json())
 
 
 class EntityType(DynatraceObject):

--- a/dynatrace/environment_v2/networkzones.py
+++ b/dynatrace/environment_v2/networkzones.py
@@ -18,41 +18,35 @@ from datetime import datetime
 from dynatrace.dynatrace_object import DynatraceObject
 from typing import List, Optional, Union, Dict, Any
 
-from dynatrace.environment_v2.schemas import EntityType, ManagementZone
 from dynatrace.http_client import HttpClient
 from dynatrace.pagination import PaginatedList
-
 
 
 class NetworkZoneService:
     ENDPOINT = "/api/v2/networkZones"
     ENDPOINT_GLOBALSETTINGS = "/api/v2/networkZoneSettings"
 
-
     def __init__(self, http_client: HttpClient):
         self.__http_client = http_client
 
-
     def list(self) -> PaginatedList["NetworkZone"]:
-        """ Lists all network zones. No params
+        """Lists all network zones. No params
 
-        :return: a list of Network Zones with details 
+        :return: a list of Network Zones with details
         """
         return PaginatedList(NetworkZone, self.__http_client, target_url=self.ENDPOINT, list_item="networkZones")
 
-
     def get(self, networkzone_id: str):
-        """ Gets parameters of specified network zone
+        """Gets parameters of specified network zone
 
         :param networkzone_id: the ID of the network zone
         :return: a Network Zone + details
         """
         response = self.__http_client.make_request(f"{self.ENDPOINT}/{networkzone_id}").json()
         return NetworkZone(raw_element=response)
-    
 
     def update(self, networkzone_id: str, alternate_zones: Optional[List[str]] = None, description: Optional[str] = None):
-        """ Updates an existing network zone or creates a new one
+        """Updates an existing network zone or creates a new one
 
         :param networkzone_id: the ID of the network zone, if none exists, will create
         :param alternate_zones: optional list of text body of alternative network zones
@@ -61,28 +55,25 @@ class NetworkZoneService:
         """
         params = {"alternativeZones": alternate_zones, "description": description}
         return self.__http_client.make_request(path=f"{self.ENDPOINT}/{networkzone_id}", params=params, method="PUT")
-    
 
     def delete(self, networkzone_id: str):
-        """ Deletes the specified network zone
+        """Deletes the specified network zone
 
         :param networkzone_id: the ID of the network zone
         :return: HTTP response
         """
         return self.__http_client.make_request(path=f"{self.ENDPOINT}/{networkzone_id}", method="DELETE")
 
-    
     def getGlobalConfig(self):
-        """ Gets the global configuration of network zones. No params
+        """Gets the global configuration of network zones. No params
         :return: Network Zone Global Settings object
         """
         response = self.__http_client.make_request(path=self.ENDPOINT_GLOBALSETTINGS).json()
         return NetworkZoneSettings(raw_element=response)
 
-
     def updateGlobalConfig(self, configuration: bool):
-        """ Updates the global configuration of network zones.
-    
+        """Updates the global configuration of network zones.
+
         :param configuration: boolean setting to enable/disable NZs
         :return: HTTP response
         """

--- a/dynatrace/environment_v2/problems.py
+++ b/dynatrace/environment_v2/problems.py
@@ -156,7 +156,7 @@ class Problem(DynatraceObject):
         self.recent_comments: Optional[CommentList] = CommentList(raw_element=raw_element.get("recentComments"))
         self.impacted_entities: Optional[List[EntityStub]] = [EntityStub(raw_element=e) for e in raw_element.get("impactedEntities", [])]
         self.linked_problem_info: Optional[LinkedProblem] = LinkedProblem(raw_element=raw_element.get("linkedProblemInfo"))
-        self.root_cause_entity: Optional[EntityStub] = EntityStub(raw_element=raw_element.get("rootCauseEntity"))
+        self.root_cause_entity: Optional[EntityStub] = EntityStub(raw_element=raw_element["rootCauseEntity"]) if raw_element.get("rootCauseEntity") else None
         self.problem_filters: Optional[List[AlertingProfileStub]] = [AlertingProfileStub(raw_element=a) for a in raw_element.get("problemFilters", [])]
         self.evidence_details: Optional[EvidenceDetails] = EvidenceDetails(raw_element=raw_element.get("evidenceDetails"))
         self.impact_analysis: Optional[ImpactAnalysis] = ImpactAnalysis(raw_element=raw_element.get("impactAnalysis"))

--- a/dynatrace/environment_v2/schemas.py
+++ b/dynatrace/environment_v2/schemas.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from enum import Enum
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from dynatrace.dynatrace_object import DynatraceObject
 
 # Schemas that don't belong to a specific api tag
@@ -28,22 +28,21 @@ class ConfigurationMetadata(DynatraceObject):
         self.current_configuration_versions: List[int] = raw_element.get("currentConfigurationVersions")
 
 
-class EntityType(DynatraceObject):
-    def _create_from_raw_data(self, raw_element: dict):
-        # TODO - Implement other properties
-        self.entity_type = raw_element.get("type")
-        self.properties = raw_element.get("properties", [])
-
-
 class VersionCompareType(Enum):
-    EQUAL: str = "EQUAL"
-    GREATER: str = "GREATER"
-    GREATER_EQUAL: str = "GREATER_EQUAL"
-    LOWER: str = "LOWER"
-    LOWER_EQUAL: str = "LOWER_EQUAL"
+    EQUAL = "EQUAL"
+    GREATER = "GREATER"
+    GREATER_EQUAL = "GREATER_EQUAL"
+    LOWER = "LOWER"
+    LOWER_EQUAL = "LOWER_EQUAL"
+
+    def __repr__(self) -> str:
+        return self.value
+
+    def __str__(self) -> str:
+        return self.value
 
 
 class ManagementZone(DynatraceObject):
     def _create_from_raw_data(self, raw_element: Dict[str, Any]):
-        self.name: str = raw_element.get("name")
-        self.id: str = raw_element.get("id")
+        self.name: str = raw_element["name"]
+        self.id: str = raw_element["id"]

--- a/test/environment_v2/test_entities.py
+++ b/test/environment_v2/test_entities.py
@@ -1,7 +1,18 @@
 from datetime import datetime
 
 from dynatrace import Dynatrace
-from dynatrace.environment_v2.monitored_entities import Entity
+from dynatrace.environment_v2.monitored_entities import (
+    Entity,
+    EntityIcon,
+    ToPosition,
+    FromPosition,
+    EntityType,
+    EntityTypePropertyDto,
+    MessageType,
+    CustomDeviceCreation,
+)
+from dynatrace.environment_v2.schemas import ManagementZone
+from dynatrace.configuration_v1.metag import METag
 
 from dynatrace.pagination import PaginatedList
 from dynatrace.utils import int64_to_datetime
@@ -11,23 +22,14 @@ def test_list(dt: Dynatrace):
     entities = dt.entities.list(
         'type("HOST")', fields="+fromRelationships,+toRelationships,+icon,+properties,+tags,+managementZones,+firstSeenTms,+lastSeenTms"
     )
-    assert isinstance(entities, PaginatedList)
     entities_list = list(entities)
-    assert len(entities_list) == 1
 
-    entity = entities_list[0]
-    assert isinstance(entity, Entity)
-    assert entity.entity_id == "HOST-82F576674F19AC16"
-    assert entity.display_name == "arch-david"
-    assert entity.first_seen == int64_to_datetime(1620821456242)
-    assert entity.last_seen == int64_to_datetime(1621177614119)
-    assert entity.properties["bitness"] == "64"
-    assert len(entity.tags) == 1
-    assert entity.tags[0].key == "citrix-prod"
-    assert len(entity.management_zones) == 0
-    assert entity.icon.primary_icon_type == "linux"
-    assert entity.from_relationships["isHostOfContainer"][0].id == "DOCKER_CONTAINER_GROUP_INSTANCE-8E2ED6F4E2AFDD89"
-    assert entity.to_relationships["runsOn"][0].id == "PROCESS_GROUP-3AD9FB79C914520C"
+    # type checks
+    assert isinstance(entities, PaginatedList)
+    assert all(isinstance(e, Entity) for e in entities)
+
+    # value checks
+    assert len(entities_list) == 1
 
 
 def test_get(dt: Dynatrace):
@@ -37,7 +39,23 @@ def test_get(dt: Dynatrace):
         time_to=datetime.utcfromtimestamp(1621177701),
         fields="+fromRelationships,+toRelationships,+icon,+properties,+tags,+managementZones,+firstSeenTms,+lastSeenTms",
     )
+
+    # type checks
     assert isinstance(entity, Entity)
+    assert isinstance(entity.entity_id, str)
+    assert isinstance(entity.display_name, str)
+    assert isinstance(entity.first_seen, (datetime, type(None)))
+    assert isinstance(entity.last_seen, (datetime, type(None)))
+    assert isinstance(entity.properties, dict)
+    assert isinstance(entity.tags, list)
+    assert all(isinstance(t, METag) for t in entity.tags)
+    assert isinstance(entity.management_zones, list)
+    assert all(isinstance(mz, ManagementZone) for mz in entity.management_zones)
+    assert isinstance(entity.icon, EntityIcon)
+    assert isinstance(entity.from_relationships, dict)
+    assert isinstance(entity.to_relationships, dict)
+
+    # value checks
     assert entity.entity_id == "HOST-82F576674F19AC16"
     assert entity.display_name == "arch-david"
     assert entity.first_seen == int64_to_datetime(1620821456242)
@@ -49,3 +67,106 @@ def test_get(dt: Dynatrace):
     assert entity.icon.primary_icon_type == "linux"
     assert entity.from_relationships["isHostOfContainer"][0].id == "DOCKER_CONTAINER_GROUP_INSTANCE-8E2ED6F4E2AFDD89"
     assert entity.to_relationships["runsOn"][0].id == "PROCESS_GROUP-3AD9FB79C914520C"
+
+
+def test_list_types(dt: Dynatrace):
+    entity_types = dt.entities.list_types(page_size=3)
+    entity_types_list = list(entity_types)
+
+    # type checks
+    assert isinstance(entity_types, PaginatedList)
+    assert all(isinstance(et, EntityType) for et in entity_types)
+
+    # value checks
+    assert len(entity_types_list) == 2
+
+
+def test_get_types(dt: Dynatrace):
+    entity_type = dt.entities.get_types(entity_type="DISK")
+
+    # type checks
+    assert isinstance(entity_type, EntityType)
+    assert isinstance(entity_type.type, str)
+    assert isinstance(entity_type.dimension_key, str)
+    assert isinstance(entity_type.entity_limit_exceeded, bool)
+    assert isinstance(entity_type.properties, list)
+    assert all(isinstance(p, EntityTypePropertyDto) for p in entity_type.properties)
+    for prop in entity_type.properties:
+        assert isinstance(prop.display_name, str)
+        assert isinstance(prop.id, str)
+        assert isinstance(prop.type, str)
+    assert isinstance(entity_type.tags, str)
+    assert isinstance(entity_type.management_zones, str)
+    assert isinstance(entity_type.from_relationships, list)
+    assert all(isinstance(fr, FromPosition) for fr in entity_type.from_relationships)
+    for rel in entity_type.from_relationships:
+        assert isinstance(rel.id, str)
+        assert isinstance(rel.to_types, list)
+        assert all(isinstance(tt, str) for tt in rel.to_types)
+    assert isinstance(entity_type.to_relationships, list)
+    assert all(isinstance(tr, ToPosition) for tr in entity_type.to_relationships)
+    for rel in entity_type.to_relationships:
+        assert isinstance(rel.id, str)
+        assert isinstance(rel.from_types, list)
+        assert all(isinstance(ft, str) for ft in rel.from_types)
+
+    # value checks
+    assert entity_type.type == "DISK"
+    assert entity_type.display_name == "Disk"
+    assert entity_type.dimension_key == "dt.entity.disk"
+    assert entity_type.entity_limit_exceeded == False
+    assert entity_type.properties[0].id == "awsNameTag"
+    assert entity_type.properties[0].type == "String"
+    assert entity_type.properties[0].display_name == "awsNameTag"
+    assert entity_type.tags == "List"
+    assert entity_type.management_zones == "List"
+    assert entity_type.from_relationships[0].id == "isDiskOf"
+    assert entity_type.from_relationships[0].to_types[0] == "HOST"
+    assert entity_type.to_relationships[0].id == "isEbsVolumeOf"
+    assert entity_type.to_relationships[0].from_types[0] == "EBS_VOLUME"
+
+
+def test_create_custom_device(dt: Dynatrace):
+    device = dt.entities.create_custom_device(
+        custom_device_id="device-one",
+        display_name="Test Device",
+        group="group-one",
+        device_type="IoT Beacon",
+        ip_addresses=["10.20.0.0", "192.168.0.1"],
+        listen_ports=[80, 8080],
+        favicon_url="https://awesome-pics.img.com/icon",
+        config_url="http://www.dashboard.com/device-one",
+        dns_names=["testdevice.testnet.net"],
+        properties={"this": "that", "lorem": "ipsum"},
+        message_type=MessageType.CUSTOM_DEVICE,
+    )
+
+    # type checks
+    assert isinstance(device, CustomDeviceCreation)
+    assert isinstance(device.custom_device_id, str)
+    assert isinstance(device.display_name, str)
+    assert isinstance(device.group, str)
+    assert isinstance(device.type, str)
+    assert isinstance(device.ip_addresses, list)
+    assert all(isinstance(ip, str) for ip in device.ip_addresses)
+    assert isinstance(device.listen_ports, list)
+    assert all(isinstance(port, int) for port in device.listen_ports)
+    assert isinstance(device.favicon_url, str)
+    assert isinstance(device.config_url, str)
+    assert isinstance(device.dns_names, list)
+    assert all(isinstance(dns, str) for dns in device.dns_names)
+    assert isinstance(device.properties, dict)
+    assert isinstance(device.message_type, MessageType)
+
+    # value checks
+    assert device.custom_device_id == "device-one"
+    assert device.display_name == "Test Device"
+    assert device.group == "group-one"
+    assert device.type == "IoT Beacon"
+    assert device.ip_addresses[0] == "10.20.0.0"
+    assert device.listen_ports[0] == 80
+    assert device.favicon_url == "https://awesome-pics.img.com/icon"
+    assert device.config_url == "http://www.dashboard.com/device-one"
+    assert device.dns_names[0] == "testdevice.testnet.net"
+    assert device.properties["this"] == "that"
+    assert device.message_type == MessageType.CUSTOM_DEVICE

--- a/test/mock_data/GET_api_v2_entityTypes_DISK.json
+++ b/test/mock_data/GET_api_v2_entityTypes_DISK.json
@@ -1,0 +1,56 @@
+{
+    "type": "DISK",
+    "displayName": "Disk",
+    "dimensionKey": "dt.entity.disk",
+    "entityLimitExceeded": false,
+    "properties": [{
+            "id": "awsNameTag",
+            "type": "String",
+            "displayName": "awsNameTag"
+        },
+        {
+            "id": "boshName",
+            "type": "String",
+            "displayName": "boshName"
+        },
+        {
+            "id": "conditionalName",
+            "type": "String",
+            "displayName": "conditionalName"
+        },
+        {
+            "id": "customizedName",
+            "type": "String",
+            "displayName": "customizedName"
+        },
+        {
+            "id": "detectedName",
+            "type": "String",
+            "displayName": "detectedName"
+        },
+        {
+            "id": "gcpZone",
+            "type": "String",
+            "displayName": "gcpZone"
+        },
+        {
+            "id": "oneAgentCustomHostName",
+            "type": "String",
+            "displayName": "oneAgentCustomHostName"
+        }
+    ],
+    "tags": "List",
+    "managementZones": "List",
+    "fromRelationships": [{
+        "id": "isDiskOf",
+        "toTypes": [
+            "HOST"
+        ]
+    }],
+    "toRelationships": [{
+        "id": "isEbsVolumeOf",
+        "fromTypes": [
+            "EBS_VOLUME"
+        ]
+    }]
+}

--- a/test/mock_data/GET_api_v2_entityTypes_e0d8c23ec365525.json
+++ b/test/mock_data/GET_api_v2_entityTypes_e0d8c23ec365525.json
@@ -1,0 +1,152 @@
+{
+    "totalCount": 2,
+    "pageSize": 2,
+    "types": [{
+            "type": "APM_SECURITY_GATEWAY",
+            "displayName": "ActiveGate",
+            "dimensionKey": "dt.entity.apm_security_gateway",
+            "entityLimitExceeded": false,
+            "properties": [{
+                    "id": "awsNameTag",
+                    "type": "String",
+                    "displayName": "awsNameTag"
+                },
+                {
+                    "id": "boshName",
+                    "type": "String",
+                    "displayName": "boshName"
+                },
+                {
+                    "id": "conditionalName",
+                    "type": "String",
+                    "displayName": "conditionalName"
+                },
+                {
+                    "id": "customizedName",
+                    "type": "String",
+                    "displayName": "customizedName"
+                },
+                {
+                    "id": "detectedName",
+                    "type": "String",
+                    "displayName": "detectedName"
+                },
+                {
+                    "id": "gcpZone",
+                    "type": "String",
+                    "displayName": "gcpZone"
+                },
+                {
+                    "id": "isContainerDeployment",
+                    "type": "Boolean",
+                    "displayName": "isContainerDeployment"
+                },
+                {
+                    "id": "oneAgentCustomHostName",
+                    "type": "String",
+                    "displayName": "oneAgentCustomHostName"
+                }
+            ],
+            "tags": "List",
+            "managementZones": "List",
+            "fromRelationships": [{
+                "id": "isLocatedIn",
+                "toTypes": [
+                    "SYNTHETIC_LOCATION"
+                ]
+            }],
+            "toRelationships": []
+        },
+        {
+            "type": "APPLICATION",
+            "displayName": "Web application",
+            "dimensionKey": "dt.entity.application",
+            "entityLimitExceeded": false,
+            "properties": [{
+                    "id": "applicationMatchTarget",
+                    "type": "Enum",
+                    "displayName": "applicationMatchTarget"
+                },
+                {
+                    "id": "applicationType",
+                    "type": "Enum",
+                    "displayName": "applicationType"
+                },
+                {
+                    "id": "awsNameTag",
+                    "type": "String",
+                    "displayName": "awsNameTag"
+                },
+                {
+                    "id": "boshName",
+                    "type": "String",
+                    "displayName": "boshName"
+                },
+                {
+                    "id": "conditionalName",
+                    "type": "String",
+                    "displayName": "conditionalName"
+                },
+                {
+                    "id": "customizedName",
+                    "type": "String",
+                    "displayName": "customizedName"
+                },
+                {
+                    "id": "detectedName",
+                    "type": "String",
+                    "displayName": "detectedName"
+                },
+                {
+                    "id": "gcpZone",
+                    "type": "String",
+                    "displayName": "gcpZone"
+                },
+                {
+                    "id": "oneAgentCustomHostName",
+                    "type": "String",
+                    "displayName": "oneAgentCustomHostName"
+                },
+                {
+                    "id": "ruleAppliedMatchType",
+                    "type": "Enum",
+                    "displayName": "ruleAppliedMatchType"
+                },
+                {
+                    "id": "ruleAppliedPattern",
+                    "type": "String",
+                    "displayName": "ruleAppliedPattern"
+                }
+            ],
+            "tags": "List",
+            "managementZones": "List",
+            "fromRelationships": [{
+                    "id": "calls",
+                    "toTypes": [
+                        "SERVICE"
+                    ]
+                },
+                {
+                    "id": "isApplicationOfSyntheticTest",
+                    "toTypes": [
+                        "HTTP_CHECK",
+                        "SYNTHETIC_TEST"
+                    ]
+                }
+            ],
+            "toRelationships": [{
+                    "id": "isApplicationMethodOf",
+                    "fromTypes": [
+                        "APPLICATION_METHOD"
+                    ]
+                },
+                {
+                    "id": "isGroupOf",
+                    "fromTypes": [
+                        "APPLICATION_METHOD_GROUP"
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Completed support for monitored entities schemas and functions. Plus, moved all entity related schemas from `environment_v2/schemas` to `environment_v2/monitored_entities` as I couldn't find any other references and seemed like they belong to that API only.