### PR TITLE
fix management zone bug, update test and mock data

### DIFF
--- a/dynatrace/environment_v2/monitored_entities.py
+++ b/dynatrace/environment_v2/monitored_entities.py
@@ -178,7 +178,7 @@ class Entity(DynatraceObject):
         self.to_relationships: Dict[str, List["EntityId"]] = {
             key: [EntityId(raw_element=entity) for entity in entities] for key, entities in raw_element.get("toRelationships", {}).items()
         }
-        self.management_zones: List[ManagementZone] = [ManagementZone(m) for m in raw_element.get("managementZones", [])]
+        self.management_zones: List[ManagementZone] = [ManagementZone(raw_element=m) for m in raw_element.get("managementZones", [])]
         self.icon: Optional[EntityIcon] = EntityIcon(raw_element=raw_element.get("icon")) if raw_element.get("icon") else None
         self.display_name: str = raw_element["displayName"]
         self.entity_id: str = raw_element["entityId"]

--- a/test/environment_v2/test_entities.py
+++ b/test/environment_v2/test_entities.py
@@ -63,7 +63,8 @@ def test_get(dt: Dynatrace):
     assert entity.properties["bitness"] == "64"
     assert len(entity.tags) == 1
     assert entity.tags[0].key == "citrix-prod"
-    assert len(entity.management_zones) == 0
+    assert len(entity.management_zones) == 1
+    assert entity.management_zones[0].id == "MANAGEMENT-ZONE-8E2ED64F4F19AC15"
     assert entity.icon.primary_icon_type == "linux"
     assert entity.from_relationships["isHostOfContainer"][0].id == "DOCKER_CONTAINER_GROUP_INSTANCE-8E2ED6F4E2AFDD89"
     assert entity.to_relationships["runsOn"][0].id == "PROCESS_GROUP-3AD9FB79C914520C"

--- a/test/mock_data/GET_api_v2_entities_HOST-82F576674F19AC16_eeb2d99e8563a18.json
+++ b/test/mock_data/GET_api_v2_entities_HOST-82F576674F19AC16_eeb2d99e8563a18.json
@@ -34,7 +34,13 @@
       "stringRepresentation": "citrix-prod"
     }
   ],
-  "managementZones": [],
+  "managementZones": [
+    {
+      "id": "MANAGEMENT-ZONE-8E2ED64F4F19AC15",
+      "name": "ZONE 1",
+      "description": "My first management zone"
+    }
+  ],
   "icon": {
     "primaryIconType": "linux"
   },


### PR DESCRIPTION
I ran into a KeyError at [dynatrace/dynatrace_object.py:32](https://github.com/dynatrace-oss/api-client-python/blob/8cbccd74e22e0d26344ff3fadb9af0fff35e5ec7/dynatrace/dynatrace_object.py#L32) calling something like `Dynatrace.entities.get("HOST-82F576674F19AC16",...)` when that entity has management zone data. Specifying the parameter `raw_element=m` at [dynatrace/environment_v2/monitored_entities.py](https://github.com/pterygota/api-client-python/blob/a99f6b384fa27ea518427959de13b12cadd85cf5/dynatrace/environment_v2/monitored_entities.py#L181) fixes this. Updated a test and mock data to demonstrate the bug and the fix.