### PR TITLE
Issue 49: Error when getting problem details - handle null grouping entity

### DIFF
--- a/dynatrace/environment_v2/problems.py
+++ b/dynatrace/environment_v2/problems.py
@@ -212,7 +212,7 @@ class Evidence(DynatraceObject):
         self.entity: EntityStub = EntityStub(raw_element=raw_element.get("entity"))
         self.root_cause_relevant: bool = raw_element.get("rootCauseRelevant")
         self.start_time: datetime = int64_to_datetime(raw_element.get("startTime"))
-        self.grouping_entity: Optional[EntityStub] = EntityStub(raw_element=raw_element.get("groupingEntity"))
+        self.grouping_entity: Optional[EntityStub] = EntityStub(raw_element=raw_element.get("groupingEntity")) if raw_element.get("groupingEntity") else None
 
 
 class EventEvidence(Evidence):


### PR DESCRIPTION
Closes #49

Maybe it changed at some point but the issue is that the groupingEntity can be present but have a null value and this gets passed to create an entity stub which then fails. This just checks for cases when it is null and returns a None value instead of trying to create an entity stub from it.

`{
        "evidenceType": "AVAILABILITY_EVIDENCE",
        "displayName": "Availability",
        "entity": {
          "entityId": {
            "id": "HOST-7EC661999923A6B9",
            "type": "HOST"
          },
          "name": "example_host"
        },
        "groupingEntity": null,
        "rootCauseRelevant": true,
        "startTime": 1636719840000,
        "endTime": 1636721100000
      }`