### PR TITLE
Fix host tag bug in v1 oneagent service

### DIFF
--- a/dynatrace/environment_v1/oneagents.py
+++ b/dynatrace/environment_v1/oneagents.py
@@ -142,7 +142,7 @@ class HostInfo(DynatraceObject):
         self.consumed_host_units: str = raw_element.get("consumedHostUnits")
         self.os_version: str = raw_element.get("osVersion")
         self.host_group: HostGroup = HostGroup(raw_element=raw_element.get("hostGroup"))
-        self.tags: List[TagInfo] = [TagInfo(t) for t in raw_element.get("tags", [])]
+        self.tags: List[TagInfo] = [TagInfo(raw_element=t) for t in raw_element.get("tags", [])]
         self.os_type: Optional[OsType] = OsType(raw_element.get("osType")) if raw_element.get("osType") else None
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="dt",
-    version="1.1.46",
+    version="1.1.47",
     packages=find_packages(),
     install_requires=["requests>=2.22"],
     tests_require=["pytest", "mock", "tox"],


### PR DESCRIPTION
The raw data for tags wasn't being passed property to create the taginfo
objects so empty taginfo objects were being created.