### PR TITLE
Event ingest and timestamp options for smartscape hosts

### DIFF
--- a/dynatrace/environment_v1/smartscape_hosts.py
+++ b/dynatrace/environment_v1/smartscape_hosts.py
@@ -15,11 +15,12 @@ limitations under the License.
 """
 from typing import Optional, Dict, Any, List, Union
 from enum import Enum
+from datetime import datetime
 
 from dynatrace.dynatrace_object import DynatraceObject
 from dynatrace.http_client import HttpClient
 from dynatrace.pagination import HeaderPaginatedList
-
+from dynatrace.utils import datetime_to_int64
 
 class RelativeTime(Enum):
     MIN = "min"
@@ -102,6 +103,8 @@ class SmartScapeHostsService:
     def list(
         self,
         relative_time: Optional[Union[RelativeTime, str]] = RelativeTime.THREE_DAYS,
+        start_timestamp: Optional[Union[datetime, str]] = None,
+        end_timestamp: Optional[Union[datetime, str]] = None,
         page_size: int = 200,
         management_zone: Optional[int] = None,
         host_group_name: Optional[str] = None,
@@ -115,10 +118,14 @@ class SmartScapeHostsService:
             Default value : None
         :param relative_time: Relative time ranger to check for (72 hours if not set)
             Default value : RelativeTime.THREE_DAYS
+        :param start_timestamp: the start timestamp of the requested timeframe, in milliseconds (UTC)
+        :param end_timestamp: the end timestamp of the requested timeframe, in milliseconds (UTC)
         """
         params = {
             "pageSize": page_size,
-            "relativeTime": RelativeTime(relative_time).value,
+            "relativeTime": RelativeTime(relative_time).value if not start_timestamp else None,
+            "startTimestamp": datetime_to_int64(start_timestamp),
+            "endTimestamp": datetime_to_int64(end_timestamp),
             "managementZone": management_zone if management_zone else None,
             "hostGroupName": host_group_name if host_group_name else None,
         }

--- a/dynatrace/environment_v2/events.py
+++ b/dynatrace/environment_v2/events.py
@@ -33,6 +33,7 @@ from dynatrace.environment_v2.schemas import ManagementZone
 
 class EventServiceV2:
     ENDPOINT_EVENTS = "/api/v2/events"
+    ENDPOINT_INGEST = "/api/v2/events/ingest"
     ENDPOINT_TYPES = "/api/v2/eventTypes"
 
     def __init__(self, http_client: HttpClient):
@@ -102,6 +103,29 @@ class EventServiceV2:
         """
         response = self.__http_client.make_request(path=f"{self.ENDPOINT_TYPES}/{event_type}")
         return EventType(raw_element=response.json(), http_client=self.__http_client)
+
+    def ingest(
+        self,
+        event_type: str,
+        title: str,
+        start_time: Optional[Union[datetime, str]] = None,
+        end_time: Optional[Union[datetime, str]] = None,
+        timeout: int = 15,
+        entity_selector: Optional[str] = None,
+        properties: Optional[Dict[str, str]] = None
+    ):
+        
+        params = {
+            "eventType": event_type,
+            "title": title,
+            "startTime": timestamp_to_string(start_time),
+            "endTime": timestamp_to_string(end_time),
+            "timeout": timeout,
+            "entitySelector": entity_selector,
+            "properties": properties
+        }
+
+        return self.__http_client.make_request(f"{self.ENDPOINT_INGEST}", method="POST", params=params).json()
 
 
 class Event(DynatraceObject):

--- a/dynatrace/environment_v2/events.py
+++ b/dynatrace/environment_v2/events.py
@@ -129,8 +129,8 @@ class EventServiceV2:
         params = {
             "eventType": event_type,
             "title": title,
-            "startTime": timestamp_to_string(start_time),
-            "endTime": timestamp_to_string(end_time),
+            "startTime": datetime_to_int64(start_time),
+            "endTime": datetime_to_int64(end_time),
             "timeout": timeout,
             "entitySelector": entity_selector,
             "properties": properties

--- a/dynatrace/environment_v2/events.py
+++ b/dynatrace/environment_v2/events.py
@@ -114,6 +114,17 @@ class EventServiceV2:
         entity_selector: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None
     ):
+        """
+        Ingests a custom event to Dynatrace
+
+        :param event_type: the type of event
+        :param title: the title of the event
+        :param start_time: the start time of the event
+        :param end_time: the end time of the event
+        :param timeout: the timeout of the event in minutes
+        :param entity_selector: the entity selector, defining a set of Dynatrace entities to be associated with the event
+        :param properties: a map of event properties
+        """
         
         params = {
             "eventType": event_type,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="dt",
-    version="1.1.55",
+    version="1.1.56",
     packages=find_packages(),
     install_requires=["requests>=2.22"],
     tests_require=["pytest", "mock", "tox"],

--- a/test/environment_v2/test_events_v2.py
+++ b/test/environment_v2/test_events_v2.py
@@ -86,3 +86,8 @@ def test_get_type(dt: Dynatrace):
     assert type_details.display_name == "Application overload prevention"
     assert type_details.severity_level == EventSeverity.INFO
     assert type_details.description == "Max user actions per minute exceeded"
+
+def test_ingest(dt: Dynatrace):
+    ingest = dt.events_v2.ingest("CUSTOM_ALERT", "Dt API Test", properties={"test": "test"}, entity_selector="type(HOST)")
+    assert isinstance(ingest, dict)
+    assert ingest["eventIngestResults"][0]["status"] == "OK"

--- a/test/mock_data/POST_api_v2_events_ingest_3dfc47521cd78f3.json
+++ b/test/mock_data/POST_api_v2_events_ingest_3dfc47521cd78f3.json
@@ -1,0 +1,1 @@
+{"reportCount": 2, "eventIngestResults": [{"correlationId": "1ffdfaec762febda", "status": "OK"}, {"correlationId": "5b7c0bfb20c21e9a", "status": "OK"}]}


### PR DESCRIPTION
closes #63 
closes #62 

Adds events v2 ingest method with all parameters.
Adds to and from timestamp options for v1 smartscape hosts list method.