### PR TITLE
Fix bug with missing slash in problem's comments

### DIFF
--- a/dynatrace/environment_v2/problems.py
+++ b/dynatrace/environment_v2/problems.py
@@ -92,7 +92,7 @@ class ProblemService:
         """
         params = {"pageSize": page_size}
         return PaginatedList(
-            target_class=Comment, http_client=self.__http_client, target_url=f"api/v2/{problem_id}/comments", target_params=params, list_item="comments"
+            target_class=Comment, http_client=self.__http_client, target_url=f"/api/v2/{problem_id}/comments", target_params=params, list_item="comments"
         )
 
     def get_comment(self, problem_id: str, comment_id: str) -> "Comment":


### PR DESCRIPTION
There's a missing '/' in the method for getting a list of comments of a problem