### PR TITLE
Check for empty 'name' field

### DIFF
--- a/dynatrace/environment_v2/schemas.py
+++ b/dynatrace/environment_v2/schemas.py
@@ -44,7 +44,7 @@ class VersionCompareType(Enum):
 
 class ManagementZone(DynatraceObject):
     def _create_from_raw_data(self, raw_element: Dict[str, Any]):
-        self.name: str = raw_element["name"]
+        self.name: str = raw_element.get("name", "")
         self.id: str = raw_element["id"]
 
     def to_json(self) -> Dict[str, Any]:


### PR DESCRIPTION
If a MZ was deleted it will be returned using just the ID, return an empty string instead if this is the case

```
{'id': '5382237453806745925'}
Traceback (most recent call last):
  File "test.py", line 26, in <module>
    problems = dt.problems.list(time_from="now-10d")
  File "/home/mark/git-repos/api-client-python/dynatrace/environment_v2/problems.py", line 63, in list
    return PaginatedList(target_class=Problem, http_client=self.__http_client, target_url=self.ENDPOINT, target_params=params, list_item="problems")
  File "/home/mark/git-repos/api-client-python/dynatrace/pagination.py", line 37, in __init__
    self.__elements = self._get_next_page()
  File "/home/mark/git-repos/api-client-python/dynatrace/pagination.py", line 68, in _get_next_page
    data = [self.__target_class(self.__http_client, response.headers, element) for element in elements]
  File "/home/mark/git-repos/api-client-python/dynatrace/pagination.py", line 68, in <listcomp>
    data = [self.__target_class(self.__http_client, response.headers, element) for element in elements]
  File "/home/mark/git-repos/api-client-python/dynatrace/dynatrace_object.py", line 35, in __init__
    self._create_from_raw_data(raw_element)
  File "/home/mark/git-repos/api-client-python/dynatrace/environment_v2/problems.py", line 154, in _create_from_raw_data
    self.management_zones: Optional[List[ManagementZone]] = [ManagementZone(raw_element=m) for m in raw_element.get("managementZones", [])]
  File "/home/mark/git-repos/api-client-python/dynatrace/environment_v2/problems.py", line 154, in <listcomp>
    self.management_zones: Optional[List[ManagementZone]] = [ManagementZone(raw_element=m) for m in raw_element.get("managementZones", [])]
  File "/home/mark/git-repos/api-client-python/dynatrace/dynatrace_object.py", line 35, in __init__
    self._create_from_raw_data(raw_element)
  File "/home/mark/git-repos/api-client-python/dynatrace/environment_v2/schemas.py", line 48, in _create_from_raw_data
    self.name: str = raw_element["name"]
KeyError: 'name'
```