### PR TITLE
add timeout option to third party test reporting

### DIFF
--- a/dynatrace/environment_v1/synthetic_third_party.py
+++ b/dynatrace/environment_v1/synthetic_third_party.py
@@ -45,6 +45,7 @@ class ThirdPartySyntheticTestsService:
         step_title: Optional[str] = None,
         detailed_steps: Optional[List["SyntheticTestStep"]] = None,
         detailed_step_results: Optional[List["SyntheticMonitorStepResult"]] = None,
+        timeout = None
     ):
 
         location = ThirdPartySyntheticLocation(self.__http_client, location_id, location_name)
@@ -66,7 +67,7 @@ class ThirdPartySyntheticTestsService:
         location_result = ThirdPartySyntheticLocationTestResult(self.__http_client, location_id, timestamp, success, step_results=detailed_step_results)
         test_result = ThirdPartySyntheticResult(self.__http_client, test_id, len(detailed_steps), [location_result])
         tests = ThirdPartySyntheticTests(self.__http_client, engine_name, timestamp, [location], [monitor], [test_result], synthetic_engine_icon_url=icon_url)
-        return tests.post()
+        return tests.post(timeout=timeout)
 
     def create_synthetic_test_step_result(self, step_id: int, timestamp: datetime, response_time: int) -> "SyntheticMonitorStepResult":
         return SyntheticMonitorStepResult(self.__http_client, step_id, timestamp, response_time_millis=response_time)
@@ -84,6 +85,7 @@ class ThirdPartySyntheticTestsService:
         event_type: str,
         reason: str,
         engine_name: str,
+        timeout = None
     ):
         opened_events: List[ThirdPartyEventOpenNotification] = []
         resolved_events = []
@@ -95,7 +97,7 @@ class ThirdPartySyntheticTestsService:
 
         if opened_events or resolved_events:
             events = ThirdPartySyntheticEvents(self.__http_client, engine_name, opened_events, resolved_events)
-            return events.post()
+            return events.post(timeout)
 
 
 class ThirdPartySyntheticTests(DynatraceObject):
@@ -120,8 +122,8 @@ class ThirdPartySyntheticTests(DynatraceObject):
         }
         super().__init__(http_client, None, raw_element)
 
-    def post(self):
-        return self._http_client.make_request(f"/api/v1/synthetic/ext/tests", params=self._raw_element, method="POST")
+    def post(self, timeout = None):
+        return self._http_client.make_request(f"/api/v1/synthetic/ext/tests", params=self._raw_element, method="POST", timeout=timeout)
 
 
 class ThirdPartySyntheticLocation(DynatraceObject):
@@ -266,8 +268,8 @@ class ThirdPartySyntheticEvents(DynatraceObject):
         }
         super().__init__(http_client, None, raw_element)
 
-    def post(self):
-        return self._http_client.make_request(f"/api/v1/synthetic/ext/events", params=self._raw_element, method="POST")
+    def post(self, timeout = None):
+        return self._http_client.make_request(f"/api/v1/synthetic/ext/events", params=self._raw_element, method="POST", timeout=timeout)
 
 
 class ThirdPartyEventOpenNotification(DynatraceObject):

--- a/dynatrace/http_client.py
+++ b/dynatrace/http_client.py
@@ -94,7 +94,7 @@ class HttpClient:
         self.mc_sso_csrf_cookie = mc_sso_csrf_cookie
 
     def make_request(
-        self, path: str, params: Optional[Any] = None, headers: Optional[Dict] = None, method="GET", data=None, files=None, query_params=None
+        self, path: str, params: Optional[Any] = None, headers: Optional[Dict] = None, method="GET", data=None, files=None, query_params=None, timeout=None
     ) -> requests.Response:
         url = f"{self.base_url}{path}"
 
@@ -122,14 +122,14 @@ class HttpClient:
             print(method, url)
             if body:
                 print(json.dumps(body, indent=2))
-        r = s.request(method, url, headers=headers, params=params, json=body, verify=False, proxies=self.proxies, data=data, cookies=cookies, files=files)
+        r = s.request(method, url, headers=headers, params=params, json=body, verify=False, proxies=self.proxies, data=data, cookies=cookies, files=files, timeout=timeout)
         self.log.debug(f"Received response '{r}'")
 
         while r.status_code == 429 and self.too_many_requests_strategy == TOO_MANY_REQUESTS_WAIT:
             sleep_amount = int(r.headers.get("retry-after", 5))
             self.log.warning(f"Sleeping for {sleep_amount}s because we have received an HTTP 429")
             time.sleep(sleep_amount)
-            r = requests.request(method, url, headers=headers, params=params, json=body, verify=False, proxies=self.proxies)
+            r = requests.request(method, url, headers=headers, params=params, json=body, verify=False, proxies=self.proxies, timeout=timeout)
 
         if r.status_code >= 400:
             raise Exception(f"Error making request to {url}: {r}. Response: {r.text}")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="dt",
-    version="1.1.57",
+    version="1.1.58",
     packages=find_packages(),
     install_requires=["requests>=2.22"],
     tests_require=["pytest", "mock", "tox"],


### PR DESCRIPTION
Timeout option to allow enforcing a timeout when reporting third party synthetic test. Primarily to avoid timeouts and long runs when used in extensions.