### PR TITLE
add timeout option at Dynatrace object level

### DIFF
--- a/dynatrace/main.py
+++ b/dynatrace/main.py
@@ -72,7 +72,8 @@ class Dynatrace:
         mc_jsession_id: Optional[str] = None,
         mc_b925d32c: Optional[str] = None,
         mc_sso_csrf_cookie: Optional[str] = None,
-        print_bodies = False
+        print_bodies = False,
+        timeout: Optional[int] = None
     ):
         self.__http_client = HttpClient(
             base_url,
@@ -85,7 +86,8 @@ class Dynatrace:
             mc_jsession_id,
             mc_b925d32c,
             mc_sso_csrf_cookie,
-            print_bodies
+            print_bodies,
+            timeout
         )
 
         self.activegates: ActiveGateService = ActiveGateService(self.__http_client)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="dt",
-    version="1.1.57",
+    version="1.1.58",
     packages=find_packages(),
     install_requires=["requests>=2.22"],
     tests_require=["pytest", "mock", "tox"],


### PR DESCRIPTION
Time out set when creating Dynatrace object via parameter, then set on every make_request sent from it.