### PR TITLE
correct list problem comments path

### DIFF
--- a/dynatrace/environment_v2/problems.py
+++ b/dynatrace/environment_v2/problems.py
@@ -92,7 +92,7 @@ class ProblemService:
         """
         params = {"pageSize": page_size}
         return PaginatedList(
-            target_class=Comment, http_client=self.__http_client, target_url=f"/api/v2/{problem_id}/comments", target_params=params, list_item="comments"
+            target_class=Comment, http_client=self.__http_client, target_url=f"{self.ENDPOINT}/{problem_id}/comments", target_params=params, list_item="comments"
         )
 
     def get_comment(self, problem_id: str, comment_id: str) -> "Comment":

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="dt",
-    version="1.1.58",
+    version="1.1.59",
     packages=find_packages(),
     install_requires=["requests>=2.22"],
     tests_require=["pytest", "mock", "tox"],


### PR DESCRIPTION
Not sure if the path used to be different or just an oversight, but noticed 404s when listing problems and found it was using the wrong path. Updated to align with other endpoints for problems.