### PR TITLE
Return HTTP response from settings api delete

### DIFF
--- a/dynatrace/environment_v2/monitored_entities.py
+++ b/dynatrace/environment_v2/monitored_entities.py
@@ -178,6 +178,7 @@ class EntityService:
 
 class Entity(DynatraceObject):
     def _create_from_raw_data(self, raw_element: Dict[str, Any]):
+        print("hi")
         self.last_seen: Optional[datetime] = int64_to_datetime(raw_element.get("lastSeenTms", 0))
         self.first_seen: Optional[datetime] = int64_to_datetime(raw_element.get("firstSeenTms", 0))
 
@@ -194,6 +195,7 @@ class Entity(DynatraceObject):
         self.icon: Optional[
             EntityIcon] = EntityIcon(raw_element=raw_element.get("icon")) if raw_element.get("icon") else None
         self.display_name: str = raw_element["displayName"]
+        self.type: str = raw_element['type']
         self.entity_id: str = raw_element["entityId"]
         self.properties: Optional[Dict[str, Any]] = raw_element.get("properties", {})
         self.tags: List[METag] = [METag(raw_element=tag) for tag in raw_element.get("tags", [])]

--- a/dynatrace/environment_v2/monitored_entities.py
+++ b/dynatrace/environment_v2/monitored_entities.py
@@ -178,7 +178,6 @@ class EntityService:
 
 class Entity(DynatraceObject):
     def _create_from_raw_data(self, raw_element: Dict[str, Any]):
-        print("hi")
         self.last_seen: Optional[datetime] = int64_to_datetime(raw_element.get("lastSeenTms", 0))
         self.first_seen: Optional[datetime] = int64_to_datetime(raw_element.get("firstSeenTms", 0))
 

--- a/dynatrace/environment_v2/settings.py
+++ b/dynatrace/environment_v2/settings.py
@@ -117,7 +117,7 @@ class SettingService:
             f"{self.OBJECTS_ENDPOINT}/{object_id}",
             method="DELETE",
             query_params=query_params,
-        ).json()
+        )
 
 
 class ModificationInfo(DynatraceObject):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="dt",
-    version="1.1.62",
+    version="1.1.63",
     packages=find_packages(),
     install_requires=["requests>=2.22"],
     tests_require=["pytest", "mock", "tox"],


### PR DESCRIPTION
Fixes: #86
Implements: #85

Settings API delete call should return the HTTP response rather than trying to return json (204 response has no body).