### PR TITLE
Fix date parser for missing ms

### DIFF
--- a/dynatrace/utils.py
+++ b/dynatrace/utils.py
@@ -23,6 +23,7 @@ import re
 
 
 ISO_8601 = "%Y-%m-%dT%H:%M:%S.%fZ"
+ISO_8601_NO_MS = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def slugify(value):
@@ -53,7 +54,11 @@ def timestamp_to_string(timestamp: Optional[Union[datetime, str]]) -> Optional[s
 
 def iso8601_to_datetime(timestamp: Optional[str]) -> Optional[datetime]:
     if isinstance(timestamp, str):
-        return datetime.strptime(timestamp, ISO_8601)
+        try:
+            return datetime.strptime(timestamp, ISO_8601)
+        except ValueError:
+            # DT API currently omitts milliseconds in response if they are 000
+            return datetime.strptime(timestamp, ISO_8601_NO_MS)
     return timestamp
 
 

--- a/test/environment_v2/test_tokens_api.py
+++ b/test/environment_v2/test_tokens_api.py
@@ -1,0 +1,12 @@
+from dynatrace import Dynatrace
+
+
+def test_parse_multiple_date_formats(dt: Dynatrace):
+    """
+    The API can currently return two different date formats.
+    If a token is created exactly at 0, then the millisecond portion is not returned by the API.
+    E.g., 2025-01-19T21:36:02.000Z will be returned as 2025-01-19T21:36:02Z by API.
+    This test ensures that both are parsed correctly.
+    """
+    tokens = dt.tokens.list()
+    assert len(tokens) == 2

--- a/test/mock_data/GET_api_v2_apiTokens_ca4f773d77d3bb7.json
+++ b/test/mock_data/GET_api_v2_apiTokens_ca4f773d77d3bb7.json
@@ -1,0 +1,1 @@
+{"totalCount": 2, "pageSize": 200, "apiTokens": [{"id": "dt0c01.34ILWD2EUD4ZYZG3LH7D2358", "name": "Without ms in timestamp", "enabled": true, "owner": "TestOwner", "creationDate": "2025-01-20T21:37:02Z"}, {"id": "dt0c01.SZQBU44KW2NIOICNL6YZ4354", "name": "With ms in timestamp", "enabled": true, "owner": "TestOwner", "creationDate": "2025-01-19T21:36:02.999Z"}]}


### PR DESCRIPTION
Dynatrace API does not return milliseconds if they are 000, e.g., 2025-01-18T21:35:03.000Z gets converted to 2025-01-18T21:35:03Z

That leads to the following error in the client API:

```
ValueError("time data '2025-01-18T21:35:03Z' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'")
```

This might be an issue in the API itself, but for now we can mitigate it by accepting both ISO pattern (with and without ms).