### PR TITLE
default to Unit.UNRECOGNIZED if unit is not present in Enum.

### DIFF
--- a/dynatrace/environment_v2/metrics.py
+++ b/dynatrace/environment_v2/metrics.py
@@ -195,6 +195,7 @@ class Unit(Enum):
     RATIO = "Ratio"
     SECOND = "Second"
     STATE = "State"
+    UNRECOGNIZED = "Unrecognized"
     UNSPECIFIED = "Unspecified"
     WEEK = "Week"
     YEAR = "Year"
@@ -227,9 +228,13 @@ class MetricDescriptor(DynatraceObject):
         self.root_cause_relevant: Optional[bool] = raw_element.get("rootCauseRelevant")
         self.tags: Optional[List[str]] = raw_element.get("tags")
         self.transformations: Optional[List[Transformation]] = [Transformation(element) for element in raw_element.get("transformations", [])]
-        self.unit: Optional[Unit] = Unit(raw_element.get("unit")) if raw_element.get("unit") else None
         self.warnings: Optional[List[str]] = raw_element.get("warnings")
 
+        # any metrics with a custom unit (not present in the Enum) will be set to 'Unrecognized'.
+        try:
+            self.unit: Optional[Unit] = Unit(raw_element.get("unit")) if raw_element.get("unit") else None
+        except ValueError:
+            self.unit = Unit.UNRECOGNIZED
 
 class ValueType(Enum):
     ERROR = "error"


### PR DESCRIPTION
The SDK currently uses an Enum to map Metric Unit types.  If an unrecognized Unit type is returned during a call (such as 1dt.metrics.list()1), the result is a **ValueError**.  I initially documented this in issue #116 .

In reality, our Dynatrace tenant contains numerous metric unit types that are not in that list.  They come from us (custom metrics), extensions, etc., and I would assume this is common across customers.  In its current state, it's not possible to pull a list of metrics from Dynatrace due to this error without hacking the SDK locally.

This update adds **Unrecognized** to the metric Unit Enum.  In addition, the logic for converting to a Metric from raw data was updated to use this option if a ValueError occurs.  This avoids the exception/breakage and allows the function to return appropriately.

Ideally the SDK would pull the list of metric types via API versus relying on a static Enum.  With this solution, custom units will not be present (and will instead be Unrecognized).  However, I'd rather have that result than have no ability to pull the data at all.

In the future, if someone chooses to implement a call to get all metric types, this approach can/should be replaced.

Thank you!