### PR TITLE
Stop using enum for metric units

### DIFF
--- a/dynatrace/environment_v2/metrics.py
+++ b/dynatrace/environment_v2/metrics.py
@@ -141,65 +141,6 @@ class Transformation(Enum):
     SETUNIT = "setUnit"
 
 
-class Unit(Enum):
-    BIT = "Bit"
-    BITPERHOUR = "BitPerHour"
-    BITPERMINUTE = "BitPerMinute"
-    BITPERSECOND = "BitPerSecond"
-    BYTE = "Byte"
-    BYTEPERHOUR = "BytePerHour"
-    BYTEPERMINUTE = "BytePerMinute"
-    BYTEPERSECOND = "BytePerSecond"
-    CORES = "Cores"
-    COUNT = "Count"
-    DAY = "Day"
-    DECIBELMILLIWATT = "DecibelMilliWatt"
-    GIBIBYTE = "GibiByte"
-    GIGA = "Giga"
-    GIGABYTE = "GigaByte"
-    HOUR = "Hour"
-    KIBIBYTE = "KibiByte"
-    KIBIBYTEPERHOUR = "KibiBytePerHour"
-    KIBIBYTEPERMINUTE = "KibiBytePerMinute"
-    KIBIBYTEPERSECOND = "KibiBytePerSecond"
-    KILO = "Kilo"
-    KILOBYTE = "KiloByte"
-    KILOBYTEPERHOUR = "KiloBytePerHour"
-    KILOBYTEPERMINUTE = "KiloBytePerMinute"
-    KILOBYTEPERSECOND = "KiloBytePerSecond"
-    MSU = "MSU"
-    MEBIBYTE = "MebiByte"
-    MEBIBYTEPERHOUR = "MebiBytePerHour"
-    MEBIBYTEPERMINUTE = "MebiBytePerMinute"
-    MEBIBYTEPERSECOND = "MebiBytePerSecond"
-    MEGA = "Mega"
-    MEGABYTE = "MegaByte"
-    MEGABYTEPERHOUR = "MegaBytePerHour"
-    MEGABYTEPERMINUTE = "MegaBytePerMinute"
-    MEGABYTEPERSECOND = "MegaBytePerSecond"
-    MICROSECOND = "MicroSecond"
-    MILLICORES = "MilliCores"
-    MILLISECOND = "MilliSecond"
-    MILLISECONDPERMINUTE = "MilliSecondPerMinute"
-    MINUTE = "Minute"
-    MONTH = "Month"
-    NANOSECOND = "NanoSecond"
-    NANOSECONDPERMINUTE = "NanoSecondPerMinute"
-    NOTAPPLICABLE = "NotApplicable"
-    PERHOUR = "PerHour"
-    PERMINUTE = "PerMinute"
-    PERSECOND = "PerSecond"
-    PERCENT = "Percent"
-    PIXEL = "Pixel"
-    PROMILLE = "Promille"
-    RATIO = "Ratio"
-    SECOND = "Second"
-    STATE = "State"
-    UNSPECIFIED = "Unspecified"
-    WEEK = "Week"
-    YEAR = "Year"
-
-
 class MetricDescriptor(DynatraceObject):
     def _create_from_raw_data(self, raw_element):
 
@@ -227,7 +168,7 @@ class MetricDescriptor(DynatraceObject):
         self.root_cause_relevant: Optional[bool] = raw_element.get("rootCauseRelevant")
         self.tags: Optional[List[str]] = raw_element.get("tags")
         self.transformations: Optional[List[Transformation]] = [Transformation(element) for element in raw_element.get("transformations", [])]
-        self.unit: Optional[Unit] = Unit(raw_element.get("unit")) if raw_element.get("unit") else None
+        self.unit: Optional[str] = raw_element.get("unit")
         self.warnings: Optional[List[str]] = raw_element.get("warnings")
 
 

--- a/dynatrace/environment_v2/problems.py
+++ b/dynatrace/environment_v2/problems.py
@@ -23,7 +23,6 @@ from typing import Optional, Union, Dict, Any, List
 from dynatrace.http_client import HttpClient
 from dynatrace.dynatrace_object import DynatraceObject
 from dynatrace.environment_v2.schemas import ManagementZone
-from dynatrace.environment_v2.metrics import Unit
 from dynatrace.environment_v2.monitored_entities import EntityStub
 from dynatrace.environment_v2.custom_tags import METag
 from dynatrace.configuration_v1.alerting_profiles import AlertingProfileStub
@@ -228,7 +227,7 @@ class TransactionalEvidence(Evidence):
         self.value_before_change_point: Optional[float] = raw_element.get("valueBeforeChangePoint")
         self.value_after_change_point: Optional[float] = raw_element.get("valueAfterChangePoint")
         self.end_time: Optional[datetime] = int64_to_datetime(raw_element.get("endTime"))
-        self.unit: Optional[Unit] = Unit(raw_element.get("unit"))
+        self.unit: Optional[str] = raw_element.get("unit")
 
 
 class MetricEvidence(Evidence):
@@ -237,7 +236,7 @@ class MetricEvidence(Evidence):
         self.value_before_change_point: Optional[float] = raw_element.get("valueBeforeChangePoint")
         self.value_after_change_point: Optional[float] = raw_element.get("valueAfterChangePoint")
         self.end_time: Optional[datetime] = int64_to_datetime(raw_element.get("endTime"))
-        self.unit: Optional[Unit] = Unit(raw_element.get("unit"))
+        self.unit: Optional[str] = raw_element.get("unit")
         self.metric_id: Optional[str] = raw_element.get("metricId")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dt"
-version = "1.1.73"
+version = "1.2.0"
 description = "Dynatrace API Python client"
 readme = "README.md"
 authors = ["David Lopes <davidribeirolopes@gmail.com>"]

--- a/test/environment_v2/test_metrics.py
+++ b/test/environment_v2/test_metrics.py
@@ -1,7 +1,7 @@
 from dynatrace import Dynatrace
 import pytest
 
-from dynatrace.environment_v2.metrics import MetricDescriptor, Unit, AggregationType, Transformation, ValueType, MetricSeriesCollection
+from dynatrace.environment_v2.metrics import MetricDescriptor, AggregationType, Transformation, ValueType, MetricSeriesCollection
 from dynatrace.pagination import PaginatedList
 from dynatrace.utils import int64_to_datetime
 
@@ -14,7 +14,7 @@ def test_list(dt: Dynatrace):
         assert metric.metric_id == "builtin:apps.other.apdex.osAndGeo"
         assert metric.display_name == "Apdex (by OS, geolocation) [mobile, custom]"
         assert metric.description == ""
-        assert metric.unit == Unit.NOTAPPLICABLE
+        assert metric.unit == "NotApplicable"
         break
 
 
@@ -29,7 +29,7 @@ def test_list_fields(dt: Dynatrace):
         assert metric.metric_id == "builtin:apps.other.apdex.osAndGeo"
         assert metric.display_name == "Apdex (by OS, geolocation) [mobile, custom]"
         assert metric.description == ""
-        assert metric.unit == Unit.NOTAPPLICABLE
+        assert metric.unit == "NotApplicable"
         assert not metric.ddu_billable
         assert metric.created is None
         assert metric.last_written == int64_to_datetime(1620514220905)
@@ -60,7 +60,7 @@ def test_list_params(dt: Dynatrace):
         assert metric.metric_id == "builtin:host.cpu.idle"
         assert metric.display_name == "CPU idle"
         assert metric.description == ""
-        assert metric.unit == Unit.PERCENT
+        assert metric.unit == "Percent"
         assert not metric.ddu_billable
         assert metric.last_written == int64_to_datetime(1621030025348)
         assert metric.entity_type == ["HOST"]
@@ -77,7 +77,7 @@ def test_get(dt: Dynatrace):
     assert metric.metric_id == "builtin:host.cpu.idle"
     assert metric.display_name == "CPU idle"
     assert metric.description == ""
-    assert metric.unit == Unit.PERCENT
+    assert metric.unit == "Percent"
     assert not metric.ddu_billable
     assert metric.last_written == int64_to_datetime(1621030565348)
     assert metric.entity_type == ["HOST"]


### PR DESCRIPTION
Closes #116 

Stop using an enum for unit types. 